### PR TITLE
Add must-gather script for DSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ The must-gather script currently collects data from following namespaces
 - redhat-ods-applications
 - redhat-ods-monitoring
 
+The script collects data from all the namespaces that has -
+- `DataSciencePipelinesApplication` instances
+
 ## Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The script collects data from all the namespaces that has -
 ## Usage
 
 ```
-oc adm must-gather --image=quay.io/modh/must-gather:v1.0.0
+oc adm must-gather --image=quay.io/modh/must-gather:stable
 ```
 ## Developer Guide
 

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -15,6 +15,8 @@ oc adm inspect namespace/$NOTEBOOKS_NS --dest-dir=must-gather || echo "Error get
 oc adm inspect namespace/$MONITORING_NS --dest-dir=must-gather  || echo "Error getting logs from ${MONITORING_NS}"
 oc adm inspect namespace/$APPLICATIONS_NS --dest-dir=must-gather  || echo "Error getting logs from ${APPLICATIONS_NS}"
 
-exit 0
+/usr/bin/gather_data_science_pipelines
+# force disk flush to ensure that all data gathered is accessible in the copy container
+sync
 
 

--- a/collection-scripts/gather_data_science_pipelines
+++ b/collection-scripts/gather_data_science_pipelines
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+datasciencepipelines=$(oc get DataSciencePipelinesApplication --all-namespaces -o=jsonpath='{range .items[*]}{.metadata.namespace}{"\n"}{end}')
+
+# Get logs from all Data Science Pipelines Application namespaces
+for i in $datasciencepipelines;
+do
+# Get pod logs for all the pods in Data Science Pipelines Application namespaces
+oc adm inspect namespace/"$i" --dest-dir=must-gather || echo "Error getting logs from $i"
+
+done
+
+sync


### PR DESCRIPTION
This PR adds script to collect logs from DSPA instances

Testing steps:
1. Install RHODS instance
2. Collect logs
```
     oc adm must-gather quay.io/modh/must-gather:pr-6
```