### PR TITLE
update: change for build

### DIFF
--- a/.tekton/must-gather-v2-19-push.yaml
+++ b/.tekton/must-gather-v2-19-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: output-image
     value: quay.io/modh/must-gather:{{target_branch}}
   - name: dockerfile
-    value: Dockerfile
+    value: Containerfile.konflux
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # current latest is point to 4.20.0
-FROM quay.io/openshift/origin-must-gather:4.17.0
+FROM quay.io/openshift/origin-must-gather:4.18.0
 
 # copy original gather from base image to gather_original
 RUN mv /usr/bin/gather /usr/bin/gather_original

--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -1,0 +1,10 @@
+# current latest is point to 4.20.0
+FROM registry.redhat.io/openshift4/ose-must-gather:v4.15.0
+
+# copy original gather from base image to gather_original
+RUN mv /usr/bin/gather /usr/bin/gather_original
+
+# copy all collection scripts to /usr/bin, including gather
+COPY collection-scripts/* /usr/bin/
+
+ENTRYPOINT ["/usr/bin/gather"]

--- a/Containerfile.konflux
+++ b/Containerfile.konflux
@@ -1,5 +1,4 @@
-# current latest is point to 4.20.0
-FROM registry.redhat.io/openshift4/ose-must-gather:v4.15.0
+FROM registry.redhat.io/openshift4/ose-must-gather-rhel9:v4.18.0
 
 # copy original gather from base image to gather_original
 RUN mv /usr/bin/gather /usr/bin/gather_original

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GATHER_IMG_VERSION ?=dev
 IMAGE_BUILDER ?= podman
 
 build-must-gather:
-	${IMAGE_BUILDER} build . -f Dockerfile -t ${GATHER_IMG}:${GATHER_IMG_VERSION}
+	${IMAGE_BUILDER} build . -f Containerfile -t ${GATHER_IMG}:${GATHER_IMG_VERSION}
 
 push-must-gather:
 	${IMAGE_BUILDER} push ${GATHER_IMG}:${GATHER_IMG_VERSION}


### PR DESCRIPTION
- rename Dockerfile to Containerfile
- uplift Dockerfile to use base 4.18.0
- add Conatinerfile for konflux built to use
- change base from quay.io x64 to redhat one for multi-arch for konflux
- the latest avaiable base is on 4.18.0 on rhel9

related to https://issues.redhat.com/browse/RHOAIENG-21323

The idea is to keep containerfile for local use, so we can build image without withour RH registry and get newer release from quay
as for product release by konflux, a simlar conatinerfile.konflux is used and enable multi-arch build by pipeline