### PR TITLE
update: CRD

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -31,8 +31,28 @@ oc adm inspect $log_collection_args "namespace/$KNATIVE_NS" --dest-dir="$DST_DIR
 oc adm inspect $log_collection_args "namespace/$AUTH_NS" --dest-dir="$DST_DIR"  || echo "Error getting logs from ${AUTH_NS}"
 
 
-# add DSCI, DSC, Auth and new component CRs
-resources=("dscinitialization" "datasciencecluster" "auths" "monitorings" "codeflares" "dashboards" "datasciencepipelines" "feastoperator" "kserves" "kueues" "modelcontrollers" "modelmeshservings" "modelregistries" "rays" "trainingoperators" "trustyais" "workbenches")
+# add DSCI, DSC, Auth and service/component/infra CRs
+resources=(
+  "dscinitialization"
+  "datasciencecluster"
+  "auths.services.platform.opendatahub.io"
+  "monitorings.services.platform.opendatahub.io"
+  "featuretrackers.features.opendatahub.io"
+  "codeflares.components.platform.opendatahub.io"
+  "dashboards.components.platform.opendatahub.io"
+  "datasciencepipelines.components.platform.opendatahub.io"
+  "feastoperators.components.platform.opendatahub.io"
+  "kserves.components.platform.opendatahub.io"
+  "kueues.components.platform.opendatahub.io"
+  "modelcontrollers.components.platform.opendatahub.io"
+  "modelmeshservings.components.platform.opendatahub.io"
+  "modelregistries.components.platform.opendatahub.io"
+  "rays.components.platform.opendatahub.io"
+  "trainingoperators.components.platform.opendatahub.io"
+  "trustyais.components.platform.opendatahub.io"
+  "workbenches.components.platform.opendatahub.io"
+  "hardwareprofiles.infrastructure.opendatahub.io"
+)
 get_operator_resource "${resources[@]}"
 
 

--- a/collection-scripts/gather_dashboard
+++ b/collection-scripts/gather_dashboard
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC1091
 source common.sh
-resources=("odhdashboardconfigs" "acceleratorprofiles" "hardwareprofiles" "odhapplications" "odhdocuments" "odhquickstarts")
+resources=("odhdashboardconfigs" "acceleratorprofiles" "hardwareprofiles.dashboard.opendatahub.io" "odhapplications" "odhdocuments" "odhquickstarts")
 
 nslist=$(get_all_namespace "${resources[@]}")
 

--- a/collection-scripts/gather_kfto
+++ b/collection-scripts/gather_kfto
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC1091
 source common.sh
-resources=("mpijobs" "mxjobs" "paddlejobs" "pytorchjob" "tfjob" "xgboostjob")
+resources=("mpijobs" "paddlejobs" "pytorchjob" "tfjob" "xgboostjob" "jaxjobs")
 
 nslist=$(get_all_namespace "${resources[@]}")
 

--- a/collection-scripts/gather_kueue
+++ b/collection-scripts/gather_kueue
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC1091
 source common.sh
-resources=("admissionchecks" "clusterqueues" "localqueues" "multikueueclusters" "multikueueconfigs" "provisioningrequestconfigs" "resourceflavors" "workloads" "workloadpriorityclasses")
+resources=("admissionchecks" "cohorts" "clusterqueues" "localqueues" "multikueueclusters" "multikueueconfigs" "provisioningrequestconfigs" "resourceflavors" "workloads" "workloadpriorityclasses")
 
 nslist=$(get_all_namespace "${resources[@]}")
 

--- a/collection-scripts/gather_mr
+++ b/collection-scripts/gather_mr
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC1091
 source common.sh
-resources=("modelregistries")
+resources=("modelregistries.modelregistry.opendatahub.io")
 # Dependent resources ossm
 resources+=("smcp" "smm" "smmr" "authorizationpolicies" "destinationrules" "gateways" "virtualservices")
 # Dependent resources authorino

--- a/collection-scripts/gather_serving
+++ b/collection-scripts/gather_serving
@@ -1,13 +1,15 @@
 #!/bin/bash
 # shellcheck disable=SC1091
 source common.sh
-resources=("inferenceservices" "inferencegraphs" "trainedmodels" "servingruntimes" "clusterstoragecontainers" "predictors")
+resources=("inferenceservices" "inferencegraphs" "trainedmodels" "servingruntimes" "clusterstoragecontainers" "predictors" "localmodelnodegroups")
 # Dependent resources ossm
 resources+=("smcp" "smm" "smmr" "gateways" "virtualservices" "authorizationpolicies" "envoyfilters")
 # Dependent resources knative
 resources+=("knativeservings" "configurations" "routes.serving.knative.dev" "services.serving.knative.dev" "revisions")
 # Dependent resources authorino
 resources+=("authconfigs" "authorinos")
+# Dependent resources NIM
+resources+=("accounts.nim.opendatahub.io")
 
 nslist=$(get_all_namespace "${resources[@]}")
 

--- a/collection-scripts/gather_trustyai
+++ b/collection-scripts/gather_trustyai
@@ -1,7 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC1091
 source common.sh
-resources=("lmevaljobs" "trustyaiservices")
+resources=("lmevaljobs" "trustyaiservices.trustyai.opendatahub.io" "guardrailsorchestrators")
 
 nslist=$(get_all_namespace "${resources[@]}")
 


### PR DESCRIPTION
- add operator's HWP
- fullname for dashboard HWP, trustyai, modelreg,
- add missing CRD: jaxjob, cohort, localmodelnodegroup, nim account, guardrailorchestrator
- remove mxjob
local build quay.io/wenzhou/must-gather:119