### PR TITLE
Changes required to publish image to red hat catalog

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>red-hat-data-services/konflux-central//renovate/default-renovate.json"
+  ]
+}

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-must-gather-rhel9:v4.18.0
+FROM registry.redhat.io/openshift4/ose-must-gather-rhel9:v4.18.0@sha256:6beb3460637f0979d03adaeab69116e3007fe8032011c1100521917a9440bc46
 
 # copy original gather from base image to gather_original
 RUN mv /usr/bin/gather /usr/bin/gather_original


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHOAIENG-29898

- Rename Containerfile.konflux to Dockerfile.konflux to match renovate regex pattern
- Use sha digest for hermetic builds
- add renovate config to enable mintmaker updates