### PR TITLE
fix(must-gather): collect custom resources instead of only discovering namespaces

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -56,10 +56,6 @@ resources=(
   "validatingadmissionpolicy"
   "validatingadmissionpolicybinding"
   "gatewayclasses"
-  "gateways"
-  "httproutes"
-  "envoyfilters"
-  "destinationrules"
   "trainers.components.platform.opendatahub.io"
 )
 get_operator_resource "${resources[@]}"

--- a/collection-scripts/gather_dashboard
+++ b/collection-scripts/gather_dashboard
@@ -5,5 +5,5 @@ resources=("odhdashboardconfigs" "acceleratorprofiles" "hardwareprofiles.dashboa
 
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"
 

--- a/collection-scripts/gather_data_science_pipelines
+++ b/collection-scripts/gather_data_science_pipelines
@@ -10,4 +10,4 @@ resources+=("clusterworkflowtemplates" "cronworkflows" "workfloweventbindings" "
 
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"

--- a/collection-scripts/gather_feastoperator
+++ b/collection-scripts/gather_feastoperator
@@ -5,4 +5,4 @@ resources=("featurestores")
 
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"

--- a/collection-scripts/gather_kfto
+++ b/collection-scripts/gather_kfto
@@ -4,9 +4,9 @@ source common.sh
 # resource for v1
 resources=("mpijobs" "paddlejobs" "pytorchjob" "tfjob" "xgboostjob" "jaxjobs")
 # resource for v2
-resource+=("jobsetoperators" "trainjobs.trainer.kubeflow.org" "trainingruntimes.trainer.kubeflow.org" "clustertrainingruntimes.trainer.kubeflow.org")
+resources+=("jobsetoperators" "trainjobs.trainer.kubeflow.org" "trainingruntimes.trainer.kubeflow.org" "clustertrainingruntimes.trainer.kubeflow.org")
 
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"
 

--- a/collection-scripts/gather_kuberay
+++ b/collection-scripts/gather_kuberay
@@ -5,4 +5,4 @@ resources=("rayclusters" "rayjobs" "rayservices")
 
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"

--- a/collection-scripts/gather_kueue
+++ b/collection-scripts/gather_kueue
@@ -5,4 +5,4 @@ resources=("admissionchecks" "cohorts" "clusterqueues" "localqueues" "multikueue
 
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"

--- a/collection-scripts/gather_lls
+++ b/collection-scripts/gather_lls
@@ -5,4 +5,4 @@ resources=("llamastackdistributions")
 
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"

--- a/collection-scripts/gather_mr
+++ b/collection-scripts/gather_mr
@@ -5,4 +5,4 @@ resources=("modelregistries.modelregistry.opendatahub.io")
 
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"

--- a/collection-scripts/gather_notebooks
+++ b/collection-scripts/gather_notebooks
@@ -4,4 +4,4 @@ source common.sh
 resources=("notebooks" "imagestreams")
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"

--- a/collection-scripts/gather_serving
+++ b/collection-scripts/gather_serving
@@ -7,10 +7,10 @@ resources+=("authconfigs" "authorinos" "authpolicies.kuadrant.io")
 # Dependent resources NIM
 resources+=("accounts.nim.opendatahub.io")
 # Dependent resources llm-d
-resources+=("llminferenceserviceconfigs" "llminferenceservices" "leaderworkersetoperators" "leaderworkersets" "gateways.gateway.networking.k8s.io" "inferencepools")
+resources+=("llminferenceserviceconfigs" "llminferenceservices" "leaderworkersetoperators" "leaderworkersets" "inferencepools")
 # Dependent resources MaaS
 resources+=("ratelimitpolicies.kuadrant.io" "kuadrants.kuadrant.io" "tokenratelimitpolicies.kuadrant.io")
 
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"

--- a/collection-scripts/gather_trustyai
+++ b/collection-scripts/gather_trustyai
@@ -5,4 +5,4 @@ resources=("lmevaljobs" "trustyaiservices.trustyai.opendatahub.io" "guardrailsor
 
 nslist=$(get_all_namespace "${resources[@]}")
 
-run_mustgather "${nslist[@]}"
+run_mustgather "$nslist" "${resources[@]}"


### PR DESCRIPTION
## Description

The must-gather scripts were listing custom resources like AuthPolicies, HTTPRoutes, InferenceServices, and LLMInferenceServiceConfigs but never actually collecting them.

Previously, `run_mustgather` used the resources array only to discover which namespaces contained those resources, then ran `oc adm inspect namespace/$ns` which only collects standard Kubernetes objects (Pods, Deployments, Services, etc.). Custom resources were silently ignored.

Additionally, `get_operator_resource` only collected the first instance of each resource type due to `awk '{print $1}'`, missing all other instances.

This change ensures custom resources are properly inspected alongside namespace contents. Gateway API and Istio resources are now collected by default for every namespace, while component-specific resources are collected by their respective gather scripts.

Verified against live cluster: the fixed must-gather now includes GatewayClasses, HTTPRoutes, AuthConfigs, Kuadrants, and LLMInferenceServiceConfigs that were previously missing.

## Steps to reproduce

Install sample [MaaS manifests](https://github.com/opendatahub-io/models-as-a-service/tree/534ad45313bb563730412a397008a31f7dca743a/scripts#deploy-openshiftsh).

> [!NOTE]
> I haven't created any `(LLM)InferenceService` for this test (and the diff below), but they should work the same way as they are defined in `resources`.

### *WITHOUT* Fix

Execute `oc adm must-gather --image=quay.io/bmajsak/odh-must-gather:2b806da` based on the latest commit in `main`.

Result:

```
cluster-scoped-resources/
├── components.platform.opendatahub.io/
├── datasciencecluster.opendatahub.io/
├── dscinitialization.opendatahub.io/
└── services.platform.opendatahub.io/
❌ NO gateway.networking.k8s.io/

namespaces/kuadrant-system/
❌ NO authorino.kuadrant.io/
❌ NO kuadrant.io/
❌ NO operator.authorino.kuadrant.io/

namespaces/maas-api/
❌ NO gateway.networking.k8s.io/
❌ NO kuadrant.io/

namespaces/openshift-ingress/
❌ NO gateway.networking.k8s.io/

namespaces/opendatahub/
❌ NO serving.kserve.io/
```

### *WITH* Fix

Execute `oc adm must-gather --image=quay.io/bmajsak/odh-must-gather:resource-fix` based on this PR.

Result:

```
cluster-scoped-resources/
├── components.platform.opendatahub.io/
├── datasciencecluster.opendatahub.io/
├── dscinitialization.opendatahub.io/
├── services.platform.opendatahub.io/
└── ✅ gateway.networking.k8s.io/gatewayclasses/
        ├── data-science-gateway-class.yaml
        └── openshift-default.yaml

namespaces/kuadrant-system/
├── ✅ authorino.kuadrant.io/authconfigs/ (4 files)
├── ✅ kuadrant.io/kuadrants/
└── ✅ operator.authorino.kuadrant.io/authorinos/

namespaces/maas-api/
├── ✅ gateway.networking.k8s.io/httproutes/maas-api-route.yaml
└── ✅ kuadrant.io/

namespaces/openshift-ingress/
├── ✅ gateway.networking.k8s.io/httproutes/oauth-callback-route.yaml
├── ✅ gateway.networking.k8s.io/gateways/openshift-ai-inference.yaml
└── ✅ kuadrant.io/

namespaces/opendatahub/
└── ✅ serving.kserve.io/llminferenceserviceconfigs/
        ├── v0-0-0-kserve-config-llm-decode-template.yaml
        ├── v0-0-0-kserve-config-llm-decode-worker-data-parallel.yaml
        ├── v0-0-0-kserve-config-llm-prefill-template.yaml
        ├── v0-0-0-kserve-config-llm-prefill-worker-data-parallel.yaml
        ├── v0-0-0-kserve-config-llm-router-route.yaml
        ├── v0-0-0-kserve-config-llm-scheduler.yaml
        ├── v0-0-0-kserve-config-llm-template-amd-rocm.yaml
        ├── v0-0-0-kserve-config-llm-template.yaml
        └── v0-0-0-kserve-config-llm-worker-data-parallel.yaml
```