### PR TITLE
feat: onboard models as a service component to must-gather

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This script also collects data from all the namespaces that has
 - `llamastackdistributions` for Llama-stack Operator
 - `mlflows.mlflow.opendatahub.io` for MLflow Operator
 - `sparkapplications` `scheduledsparkapplications` `sparkconnects` for Spark Operator
+- `maasmodelrefs` `maasauthpolicies` `maassubscriptions` for Models as a Service
 
 ## Usage on OpenShift
 
@@ -57,6 +58,7 @@ Full list of supported components see table below:
 | llamastack      | Llama-stack Operator       |
 | mlflow          | MLflow Operator            |
 | sparkoperator   | Spark Operator             |
+| maas            | Models as a Service        |
 | llm-d           | LLM-D / RHAII (auto-enabled for xKS)|
 
 for example to 'kserve':

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -35,9 +35,7 @@ if [[ "${K8S_DISTRO}" == "ocp" ]]; then
     NOTEBOOKS_NS=${NOTEBOOK_NAMESPACE:-rhods-notebooks}
     MONITORING_NS=${MONITORING_NAMESPACE:-redhat-ods-monitoring}
     MODELREG_NS=${MODEL_REGISTRIES_NAMESPACE:-rhoai-model-registries}
-    # MaaS namespace
     KUADRANT_NS="kuadrant-system"
-    MAAS_NS=${MAAS_NAMESPACE:-maas-api}
     # dependent operator namespace
     GW_NS=${GW_NS:-openshift-ingress}
 
@@ -52,7 +50,6 @@ if [[ "${K8S_DISTRO}" == "ocp" ]]; then
     oc adm inspect $log_collection_args "namespace/$MODELREG_NS" --dest-dir="$DST_DIR"  || echo "Error getting logs from ${MODELREG_NS}"
     oc adm inspect $log_collection_args "namespace/$GW_NS" --dest-dir="$DST_DIR"  || echo "Error getting logs from ${GW_NS}"
     oc adm inspect $log_collection_args "namespace/$KUADRANT_NS" --dest-dir="$DST_DIR"  || echo "Error getting logs from ${KUADRANT_NS}"
-    oc adm inspect $log_collection_args "namespace/$MAAS_NS" --dest-dir="$DST_DIR"  || echo "Error getting logs from ${MAAS_NS}"
 
     # add DSCI, DSC, Auth and service/component/infra CRs
     resources=(
@@ -139,6 +136,9 @@ case "$component" in
     "sparkoperator")
         "${SCRIPT_DIR}/gather_sparkoperator"
         ;;
+    "maas")
+        "${SCRIPT_DIR}/gather_models_as_a_service"
+        ;;
     "llm-d")
         "${SCRIPT_DIR}/llm-d/gather_llmd.sh"
         # WVA is optional, controlled by ENABLE_WVA env var (default: false)
@@ -159,6 +159,7 @@ case "$component" in
         "${SCRIPT_DIR}/gather_lls"
         "${SCRIPT_DIR}/gather_mlflow"
         "${SCRIPT_DIR}/gather_sparkoperator"
+        "${SCRIPT_DIR}/gather_models_as_a_service"
         ;;
 esac
 

--- a/collection-scripts/gather_models_as_a_service
+++ b/collection-scripts/gather_models_as_a_service
@@ -1,0 +1,11 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+: "${SCRIPT_DIR:=$(dirname "$0")}"
+source "${SCRIPT_DIR}/common.sh"
+
+# MaaS core CRDs
+resources=("maasmodelrefs.maas.opendatahub.io" "maasauthpolicies.maas.opendatahub.io" "maassubscriptions.maas.opendatahub.io" "externalmodels.maas.opendatahub.io")
+
+nslist=$(get_all_namespace "${resources[@]}")
+
+run_mustgather "$nslist" "${resources[@]}"


### PR DESCRIPTION
## Summary
Onboard Models as a Service (MaaS).

## Description
- Add a new collection script for MaaS, and other required changes

## How it was tested
- Ran shellcheck and bash syntax validation (`bash -n`) on all modified scripts — both passed cleanly.
- Built a custom must-gather image and tested on a live OpenShift 4.21.4 cluster with MaaS installed.
- Ran targeted MaaS component collection:
 ```
oc adm must-gather --image=quay.io/chkulkar/must-gather:maas-test-v2 -- "export COMPONENT=maas; /usr/bin/gather"
```
- Verified that `gather_models_as_a_service` dynamically discovered namespaces containing MaaS CRDs and collected resources from them.
- Verified that `kuadrant-system` namespace was inspected and its resources were captured.
- Confirmed that MaaS operator-level CRDs were collected via `get_operator_resource`.
- Confirmed that the script exits cleanly on clusters without MaaS installed. Missing CRDs and namespaces are logged and skipped gracefully without blocking other component collection.

