### PR TITLE
Update dockerfile.konflux to have updated image of ose-must-gather

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/openshift4/ose-must-gather-rhel9:v4.18.0@sha256:16c67cfcae221ea9db9dcfce1c2efc0a6bfcdcff1c589513d7826cd91c37ca11
+FROM registry.redhat.io/openshift4/ose-must-gather-rhel9:v4.20@sha256:2c7248879f975086b0bfb59bb176c9f381e77caf3dfad40227ebe6404932f3ee
 
 # copy original gather from base image to gather_original
 RUN mv /usr/bin/gather /usr/bin/gather_original


### PR DESCRIPTION
-   Upgrade base image from v4.18.0 to v4.20 to fix CVE-2026-33747                                                                                                                                                                                                                                                                                                                                                         
-   This resolves the BuildKit vulnerability (GO-2026-4858) in the bin/oc binary.       

Closes RHOAIENG-55686                                                                                                                   
                                                                                      