### PR TITLE
feat: add tenants CRD to models as a service must-gather

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This script also collects data from all the namespaces that has
 - `llamastackdistributions` for Llama-stack Operator
 - `mlflows.mlflow.opendatahub.io` for MLflow Operator
 - `sparkapplications` `scheduledsparkapplications` `sparkconnects` for Spark Operator
-- `maasmodelrefs` `maasauthpolicies` `maassubscriptions` for Models as a Service
+- `maasmodelrefs` `maasauthpolicies` `maassubscriptions` `externalmodels` `tenants` for Models as a Service
 
 ## Usage on OpenShift
 

--- a/collection-scripts/gather_models_as_a_service
+++ b/collection-scripts/gather_models_as_a_service
@@ -4,7 +4,7 @@
 source "${SCRIPT_DIR}/common.sh"
 
 # MaaS core CRDs
-resources=("maasmodelrefs.maas.opendatahub.io" "maasauthpolicies.maas.opendatahub.io" "maassubscriptions.maas.opendatahub.io" "externalmodels.maas.opendatahub.io")
+resources=("maasmodelrefs.maas.opendatahub.io" "maasauthpolicies.maas.opendatahub.io" "maassubscriptions.maas.opendatahub.io" "externalmodels.maas.opendatahub.io" "tenants.maas.opendatahub.io")
 
 nslist=$(get_all_namespace "${resources[@]}")
 


### PR DESCRIPTION
## Summary

Add `tenants.maas.opendatahub.io` CRD to the Models as a Service must-gather collection and update the README accordingly.

## Description

- Add `tenants.maas.opendatahub.io` to the resources array in `gather_models_as_a_service` collection script.
- Update README to list all five MaaS CRDs: `maasmodelrefs`, `maasauthpolicies`, `maassubscriptions`, `externalmodels`, and `tenants`.

## How it was tested

- Verified the bash array syntax is correct with each CRD as a separate element.
- Confirmed the README accurately reflects the CRDs collected by the script.

Made with [Cursor](https://cursor.com)