### PR TITLE
[rhoai-3.5-ea.1] RHOAIENG-65796 - must-gather broken: gather script renamed to gather.…

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,5 +17,7 @@ RUN mv /usr/bin/gather /usr/bin/gather_original
 
 # copy all collection scripts to /usr/bin
 COPY collection-scripts /usr/bin
+# oc adm must-gather expects /usr/bin/gather
+RUN mv /usr/bin/gather.sh /usr/bin/gather
 
-ENTRYPOINT ["/usr/bin/gather.sh"]
+ENTRYPOINT ["/usr/bin/gather"]

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -9,8 +9,10 @@ COPY --from=builder /usr/bin/kubectl /usr/bin/kubectl
 COPY bin/helm /usr/local/bin/helm
 # copy all collection scripts to /usr/bin, including gather and subdirectories
 COPY collection-scripts /usr/bin
+# oc adm must-gather expects /usr/bin/gather
+RUN mv /usr/bin/gather.sh /usr/bin/gather
 
-ENTRYPOINT ["/usr/bin/gather.sh"]
+ENTRYPOINT ["/usr/bin/gather"]
 
 LABEL com.redhat.component="odh-must-gather" \
       name="odh-must-gather" \


### PR DESCRIPTION
…sh but oc adm must-gather expects /usr/bin/gather

backport of #271 