### PR TITLE
Add: support for agents operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This script also collects data from all the namespaces that has
 - `mlflows.mlflow.opendatahub.io` for MLflow Operator
 - `sparkapplications` `scheduledsparkapplications` `sparkconnects` for Spark Operator
 - `maasmodelrefs` `maasauthpolicies` `maassubscriptions` `externalmodels` `tenants` for Models as a Service
+- `agentcards.agent.kagenti.dev` `agentruntimes.agent.kagenti.dev` `sandboxes.agents.x-k8s.io` for Agents Operator
 
 ## Usage on OpenShift
 
@@ -59,6 +60,7 @@ Full list of supported components see table below:
 | mlflow          | MLflow Operator            |
 | sparkoperator   | Spark Operator             |
 | maas            | Models as a Service        |
+| agentsoperator  | Agents Operator            |
 | llm-d           | LLM-D / RHAII (auto-enabled for xKS)|
 
 for example to 'kserve':

--- a/collection-scripts/gather.sh
+++ b/collection-scripts/gather.sh
@@ -94,6 +94,7 @@ if [[ "${K8S_DISTRO}" == "ocp" ]]; then
       "gatewayclasses"
       "trainers.components.platform.opendatahub.io"
       "sparkoperators.components.platform.opendatahub.io"
+      "agentsoperators.components.platform.opendatahub.io"
     )
     get_operator_resource "${resources[@]}"
 
@@ -166,6 +167,9 @@ case "$component" in
     "maas")
         "${SCRIPT_DIR}/gather_models_as_a_service.sh"
         ;;
+    "agentsoperator")
+        "${SCRIPT_DIR}/gather_agentsoperator.sh"
+        ;;
     "llm-d")
         "${SCRIPT_DIR}/llm-d/gather_llmd.sh"
         # WVA is optional, controlled by ENABLE_WVA env var (default: false)
@@ -199,6 +203,7 @@ case "$component" in
         "${SCRIPT_DIR}/gather_mlflow.sh" & job_pids[$!]="mlflow"
         "${SCRIPT_DIR}/gather_sparkoperator.sh" & job_pids[$!]="spark"
         "${SCRIPT_DIR}/gather_models_as_a_service.sh" & job_pids[$!]="maas"
+        "${SCRIPT_DIR}/gather_agentsoperator.sh" & job_pids[$!]="agentsoperator"
 
         echo "Waiting for ${#job_pids[@]} jobs to complete..."
 

--- a/collection-scripts/gather_agentsoperator.sh
+++ b/collection-scripts/gather_agentsoperator.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+: "${SCRIPT_DIR:=$(dirname "$0")}"
+source "${SCRIPT_DIR}/common.sh"
+resources=("agentruntimes.agent.kagenti.dev")
+
+nslist=$(get_all_namespace "${resources[@]}")
+
+run_mustgather "$nslist" "${resources[@]}"


### PR DESCRIPTION
This PR adds support for agents operator CRD and the CRD it manages: AgentRuntime.

- Add gather_agentsoperator.sh to add support for AgentRuntime CRs. 
- Wire it into gather.sh as both a targeted component (COMPONENT=agentsoperator) and a parallel job in the full collection path. 
- Add agentsoperators.components.platform.opendatahub.io to the cluster-scoped resource list. 
- Update README with collected resources and COMPONENT table entry.

Tested with custom must-gather image on ROSA cluster with RHOAI 3.4.0

must-gather Jira issue: https://redhat.atlassian.net/browse/RHOAIENG-62620
The upstream PR to onboard agents operator: https://github.com/opendatahub-io/opendatahub-operator/pull/3584