### PR TITLE
feat: onboard OGX Operator to must-gather collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This script also collects data from all the namespaces that has
 - `sparkapplications` `scheduledsparkapplications` `sparkconnects` for Spark Operator
 - `aitenants` `configs` `externalmodels` `maasauthpolicies` `maasmodelrefs` `maassubscriptions` `maastenantconfigs` `tenants` `externalmodels.inference.opendatahub.io` `externalproviders.inference.opendatahub.io` `llmbatchgateways` for AI Gateway (includes Models as a Service)
 - `mcpservers` for MCP Lifecycle Operator
+- `ogxservers` for OGX Operator
 
 ## Usage on OpenShift
 
@@ -61,6 +62,7 @@ Full list of supported components see table below:
 | sparkoperator   | Spark Operator                                  |
 | aigateway       | AI Gateway: batch-gateway, Models as a Service  |
 | mcplo           | MCP Lifecycle Operator                          |
+| ogx             | OGX Operator                                    |
 | llm-d           | LLM-D / RHAII (auto-enabled for xKS)            |
 
 for example to 'kserve':

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ This script also collects data from all the namespaces that has
 - `notebooks` `imagestreams` for Workbench component
 - `modelregistries.modelregistry.opendatahub.io` for Model Registry component
 - `featurestores` for Feast Operator
-- `llamastackdistributions` for Llama-stack Operator
 - `mlflows.mlflow.opendatahub.io` for MLflow Operator
 - `sparkapplications` `scheduledsparkapplications` `sparkconnects` for Spark Operator
 - `aitenants` `configs` `externalmodels` `maasauthpolicies` `maasmodelrefs` `maassubscriptions` `maastenantconfigs` `tenants` `externalmodels.inference.opendatahub.io` `externalproviders.inference.opendatahub.io` `llmbatchgateways` for AI Gateway (includes Models as a Service)
@@ -57,7 +56,6 @@ Full list of supported components see table below:
 | modelregistry   | Model Registry                                  |
 | trustyai        | TrustyAI                                        |
 | feastoperator   | Feast Operator                                  |
-| llamastack      | Llama-stack Operator                            |
 | mlflow          | MLflow Operator                                 |
 | sparkoperator   | Spark Operator                                  |
 | aigateway       | AI Gateway: batch-gateway, Models as a Service  |

--- a/collection-scripts/gather.sh
+++ b/collection-scripts/gather.sh
@@ -84,7 +84,6 @@ if [[ "${K8S_DISTRO}" == "ocp" ]]; then
       "trainingoperators.components.platform.opendatahub.io"
       "trustyais.components.platform.opendatahub.io"
       "workbenches.components.platform.opendatahub.io"
-      "llamastackoperators.components.platform.opendatahub.io"
       "mlflowoperators.components.platform.opendatahub.io"
       "mutatingwebhookconfigurations.admissionregistration.k8s.io"
       "validationwebhookconfigurations.admissionregistration.k8s.io"
@@ -156,9 +155,6 @@ case "$component" in
     "feastoperator")
         "${SCRIPT_DIR}/gather_feastoperator.sh"
         ;;
-    "llamastack")
-        "${SCRIPT_DIR}/gather_lls.sh"
-        ;;
     "mlflow")
         "${SCRIPT_DIR}/gather_mlflow.sh"
         ;;
@@ -203,7 +199,6 @@ case "$component" in
         "${SCRIPT_DIR}/gather_mr.sh" & job_pids[$!]="modelregistry"
         "${SCRIPT_DIR}/gather_trustyai.sh" & job_pids[$!]="trustyai"
         "${SCRIPT_DIR}/gather_feastoperator.sh" & job_pids[$!]="feastoperator"
-        "${SCRIPT_DIR}/gather_lls.sh" & job_pids[$!]="llamastack"
         "${SCRIPT_DIR}/gather_mlflow.sh" & job_pids[$!]="mlflow"
         "${SCRIPT_DIR}/gather_sparkoperator.sh" & job_pids[$!]="spark"
         "${SCRIPT_DIR}/gather_aigateway.sh" & job_pids[$!]="aigateway"

--- a/collection-scripts/gather.sh
+++ b/collection-scripts/gather.sh
@@ -95,6 +95,7 @@ if [[ "${K8S_DISTRO}" == "ocp" ]]; then
       "sparkoperators.components.platform.opendatahub.io"
       "aigateways.components.platform.opendatahub.io"
       "mcplifecycleoperators.components.platform.opendatahub.io"
+      "ogxs.components.platform.opendatahub.io"
     )
     get_operator_resource "${resources[@]}"
 
@@ -170,6 +171,9 @@ case "$component" in
     "mcplo")
         "${SCRIPT_DIR}/gather_mcp_lifecycle_operator.sh"
         ;;
+    "ogx")
+        "${SCRIPT_DIR}/gather_ogx.sh"
+        ;;
     "llm-d")
         "${SCRIPT_DIR}/llm-d/gather_llmd.sh"
         # WVA is optional, controlled by ENABLE_WVA env var (default: false)
@@ -204,6 +208,7 @@ case "$component" in
         "${SCRIPT_DIR}/gather_sparkoperator.sh" & job_pids[$!]="spark"
         "${SCRIPT_DIR}/gather_aigateway.sh" & job_pids[$!]="aigateway"
         "${SCRIPT_DIR}/gather_mcp_lifecycle_operator.sh" & job_pids[$!]="mcplo"
+        "${SCRIPT_DIR}/gather_ogx.sh" & job_pids[$!]="ogx"
 
         echo "Waiting for ${#job_pids[@]} jobs to complete..."
 

--- a/collection-scripts/gather_lls.sh
+++ b/collection-scripts/gather_lls.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# shellcheck disable=SC1091
-: "${SCRIPT_DIR:=$(dirname "$0")}"
-source "${SCRIPT_DIR}/common.sh"
-resources=("llamastackdistributions")
-
-nslist=$(get_all_namespace "${resources[@]}")
-
-run_mustgather "$nslist" "${resources[@]}"

--- a/collection-scripts/gather_ogx.sh
+++ b/collection-scripts/gather_ogx.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+: "${SCRIPT_DIR:=$(dirname "$0")}"
+source "${SCRIPT_DIR}/common.sh"
+resources=("ogxservers")
+
+nslist=$(get_all_namespace "${resources[@]}")
+
+run_mustgather "$nslist" "${resources[@]}"


### PR DESCRIPTION
Adds collection of ogxservers CRD (ogx.io/v1beta1) from the ogx-k8s-operator, wires it into gather.sh as both a standalone COMPONENT=ogx option and in the parallel "all" collection, and documents it in the README.