### PR TITLE
chore: bump builder and base images to fix crypto vulnerability

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,6 +1,6 @@
 # To get kubectl CLI (1.33.3)
-FROM registry.redhat.io/openshift4/ose-cli-rhel9@sha256:08c3d93f2eaf1c070374c978fe5bb619a8c7af23d7bbbbdf8baa5ef793cc5e0c AS builder
-FROM registry.redhat.io/openshift4/ose-must-gather-rhel9:v4.20.@sha256:2c7248879f975086b0bfb59bb176c9f381e77caf3dfad40227ebe6404932f3ee
+FROM registry.redhat.io/openshift4/ose-cli-rhel9@sha256:74b8d9cff26ab06c9d7bbeb115f3d2d4319dafb5e9f367b231d40f610b152391 AS builder
+FROM registry.redhat.io/openshift4/ose-must-gather-rhel9:v4.21@sha256:2355b2efc7cd77576e8aa87b8b01a466a61037e0b65a6a371607a34bec31d4b6
 # copy original gather from base image to gather_original
 RUN mv /usr/bin/gather /usr/bin/gather_original
 # Copy kubectl from builder stage


### PR DESCRIPTION
## Description

This PR bumps the builder (`ose-cli-rhel9`) and base (`ose-must-gather-rhel9`) images to the latest versions which use golang.org/x/crypto `v0.54.0` which doesn't contain the vulnerability described in [RHOAIENG-80852](https://redhat.atlassian.net/browse/RHOAIENG-80852).

Once this PR is merged, the changes will be cherry-picked to the `odh-must-gather-v3-5` branch.